### PR TITLE
Fixed request error: 'bytes' object has no attribute 'get'

### DIFF
--- a/aheadfork.py
+++ b/aheadfork.py
@@ -50,11 +50,11 @@ def get_forks():
             
     # determine branches of repo likely to be the primary branch
     branches_url = "https://api.github.com/repos/%s/branches"
-    branches = session.get(branches_url % REPO, headers={'Accept': 'application/vnd.github.v3+json'})
+    branches = session.get(branches_url % REPO, headers={'Accept': 'application/vnd.github.v3+json'}).json()
     primary_branch_options = []
     for branch in branches:
         branch_name = branch.get("name")
-        if branch_name == "master" || branch_name == "main" || branch.get("protected"):
+        if branch_name == "master" or branch_name == "main" or branch.get("protected"):
             primary_branch_options.append(branch_name)
     
     # ask user to choose branch if cannot infer primary branch
@@ -118,7 +118,6 @@ def get_forks():
         })
 
     return forks
-
 
 if __name__ == "__main__":
     if len(sys.argv) >= 3:


### PR DESCRIPTION
Maybe due to some change in requests library, or maybe github's response, just using session.get() returned bytes,
we needed json to iterate over in a later for loop, fixed it by adding session.get()**.json()**

The error was:

**[-] Error: 'bytes' object has no attribute 'get'**

> ![image](https://user-images.githubusercontent.com/37269665/131213087-5186cb79-c0f9-4cd1-84ac-59cf85b5131d.png)
